### PR TITLE
yosys: Add python3-* dependencies for yosys-smtbmc

### DIFF
--- a/recipes-synthesis/yosys/yosys_git.bb
+++ b/recipes-synthesis/yosys/yosys_git.bb
@@ -26,7 +26,15 @@ DEPENDS = " \
 		libffi \
 		"
 
+PACKAGE_BEFORE_PN += "${PN}-smtbmc"
+
 RDEPENDS_${PN} += "berkeley-abc bash"
+RDEPENDS_${PN}-smtbmc += "python3-core python3-resource python3-threading"
+
+FILES_${PN}-smtbmc += " \
+		${bindir}/yosys-smtbmc \
+		${datadir}/yosys/python3/* \
+		"
 
 # OE modifies target tcl to populate includes into subdirectory but never sets that up in .pc
 CXXFLAGS_append = " -I=${includedir}/tcl8.6"


### PR DESCRIPTION
Currently, yosys-smtbmc doesn't pull in python3 and the required modules:
root@qemux86-64:~# yosys-smtbmc
env: can't execute 'python3': No such file or directory

Create a separate package for yosys-smtbmc and add the required python3-*
dependencies.

Signed-off-by: Ovidiu Panait <ovidiu.panait@gmail.com>