### PR TITLE
recipes-support: Add recipes for Z3, CryptoMiniSat and Boolector STM solvers

### DIFF
--- a/recipes-examples/meta/fpga-toolkit.bb
+++ b/recipes-examples/meta/fpga-toolkit.bb
@@ -19,6 +19,8 @@ TOOLCHAIN_HOST_TASK = " \
     nativesdk-prjtrellis-openocd \
     nativesdk-yosys \
     nativesdk-yices2 \
+    nativesdk-z3 \
+    nativesdk-boolector \
     nativesdk-arachne-pnr \
     nativesdk-nextpnr-ice40 \
     nativesdk-nextpnr-ecp5 \

--- a/recipes-examples/meta/hdl-build-all.bb
+++ b/recipes-examples/meta/hdl-build-all.bb
@@ -7,6 +7,8 @@ TARGETS = " \
     prjtrellis \
     yosys \
     yices2 \
+    z3 \
+    boolector \
     arachne-pnr \
     nextpnr-ice40 \
     nextpnr-ecp5 \

--- a/recipes-support/boolector/boolector_git.bb
+++ b/recipes-support/boolector/boolector_git.bb
@@ -1,0 +1,35 @@
+DESCRIPTION = "Boolector is a Satisfiability Modulo Theories (SMT) solver for \
+the theories of fixed-size bit-vectors, arrays and uninterpreted functions."
+HOMEPAGE = "https://boolector.github.io/"
+LICENSE = "MIT"
+SECTION = "devel/verilog"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=6b4c24fbbe55ff1229acdef3dec0298b"
+SRC_URI = "git://github.com/Boolector/boolector;protocol=https"
+SRCREV = "d46fb7b818932398445495d44d6e2233cb56bf27"
+
+S = "${WORKDIR}/git"
+
+BOOLECTOR_VERSION = "3.1.0"
+PV = "${BOOLECTOR_VERSION}+git${SRCPV}"
+
+inherit cmake python3native
+
+EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=ON"
+
+DEPENDS = "\
+        btor2tools \
+        cryptominisat \
+        "
+
+do_install_append() {
+	# Fix QA Issue: -dev package contains non-symlink .so:
+	for lib in $(ls ${D}${libdir}/*.so); do
+		if ! [ -L ${lib} ]; then
+			mv ${lib} ${lib}.${BOOLECTOR_VERSION};
+			ln -sfr ${lib}.${BOOLECTOR_VERSION} ${lib};
+		fi
+	done
+}
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-support/boolector/btor2tools_git.bb
+++ b/recipes-support/boolector/btor2tools_git.bb
@@ -1,0 +1,36 @@
+DESCRIPTION = "Btor2tools is a generic parser and tool package for the BTOR2 format."
+HOMEPAGE = "https://github.com/boolector/btor2tools"
+LICENSE = "MIT"
+SECTION = "devel/verilog"
+
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=8be17480d0587bf9ac39c209f6cb8c76"
+SRC_URI = "git://github.com/Boolector/btor2tools;protocol=https"
+SRCREV = "9831f9909fb283752a3d6d60d43613173bd8af42"
+
+S = "${WORKDIR}/git"
+
+BTOR2TOOLS_VERSION = "1.0.0"
+PV = "${BTOR2TOOLS_VERSION}+git${SRCPV}"
+
+inherit cmake
+
+# Fix QA Issue: No GNU_HASH in the ELF binary
+TARGET_CC_ARCH += "${LDFLAGS}"
+
+# Currently there is no cmake install target available:
+# ninja: error: unknown target 'install'
+do_install() {
+	install -d ${D}${bindir}
+	install -m 0755 ${B}/bin/* ${D}${bindir}
+
+	install -d ${D}${includedir}
+	install -d ${D}${includedir}/btor2parser
+	install -m 0644 ${S}/src/btor2parser/btor2parser.h ${D}/${includedir}/btor2parser
+
+	install -d ${D}${libdir}
+	# Fix "-dev package contains non-symlink .so" dev-elf error
+	install -m 0755 ${B}/lib/libbtor2parser.so ${D}${libdir}/libbtor2parser.so.${BTOR2TOOLS_VERSION}
+	ln -sfr ${D}${libdir}/libbtor2parser.so.${BTOR2TOOLS_VERSION} ${D}${libdir}/libbtor2parser.so
+}
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-support/cryptominisat/cryptominisat_git.bb
+++ b/recipes-support/cryptominisat/cryptominisat_git.bb
@@ -1,0 +1,33 @@
+DESCRIPTION = "CryptoMiniSat is an advanced incremental SAT solver."
+HOMEPAGE = " https://www.msoos.org"
+LICENSE = "MIT"
+SECTION = "devel/verilog"
+
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=7cdd497f1ddb031d004fad321c45d8df"
+SRC_URI = "git://github.com/msoos/cryptominisat;protocol=https"
+SRCREV = "e440d535cb4500706b38ec5d655111a735dbb60e"
+
+S = "${WORKDIR}/git"
+
+PV = "5.6.8+git${SRCPV}"
+
+inherit cmake python3native
+
+EXTRA_OECMAKE = "-DENABLE_PYTHON_INTERFACE=OFF -DNOM4RI=ON -DONLY_SIMPLE=ON"
+
+DEPENDS = " \
+        boost \
+        "
+
+# Work around the following cross-compiling error:
+# | -- Performing Test HAVE__FPU_SETCW
+# | CMake Error: TRY_RUN() invoked in cross-compiling mode, please set the following cache variables appropriately:
+# |    HAVE__FPU_SETCW_EXITCODE (advanced)
+# |    HAVE__FPU_SETCW_EXITCODE__TRYRUN_OUTPUT (advanced)
+cmake_do_generate_toolchain_file_append() {
+	cat >> ${WORKDIR}/toolchain.cmake <<EOF
+set(HAVE__FPU_SETCW FALSE CACHE INTERNAL "" FORCE)
+EOF
+}
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-support/z3/z3_git.bb
+++ b/recipes-support/z3/z3_git.bb
@@ -1,0 +1,16 @@
+DESCRIPTION = "Z3 is a theorem prover from Microsoft Research."
+HOMEPAGE = "https://github.com/Z3Prover/z3/wiki"
+LICENSE = "MIT"
+SECTION = "devel/verilog"
+
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=5f03ad1486a2e4ce71200ce0f9721557"
+SRC_URI = "git://github.com/Z3Prover/z3;protocol=https"
+SRCREV = "773b27296fac8ad57e3f2868c24fd0e8243fd901"
+
+S = "${WORKDIR}/git"
+
+PV = "4.8.7+git${SRCPV}"
+
+inherit cmake python3native
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
These SMT solvers can be used as backend for yosys-smtbmc to formally verify a design.

More information about all the SMT backends available for yosys-smtbmc can be found in the SymbiYosys readme page:
https://symbiyosys.readthedocs.io/en/latest/