### PR TITLE
prjtrellis: update SRC_URI

### DIFF
--- a/recipes-fpga/prjtrellis/prjtrellis-db.bb
+++ b/recipes-fpga/prjtrellis/prjtrellis-db.bb
@@ -5,7 +5,7 @@ SECTION = "devel/fpga"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=65d3616852dbf7b1a6d4b53b00626032"
 
-SRC_URI = "git://github.com/SymbiFlow/prjtrellis-db;protocol=https"
+SRC_URI = "git://github.com/YosysHQ/prjtrellis-db;protocol=https"
 SRCREV = "c137076fdd8bfca3d2bf9cdacda9983dbbec599a"
 
 S = "${WORKDIR}/git"

--- a/recipes-fpga/prjtrellis/prjtrellis.inc
+++ b/recipes-fpga/prjtrellis/prjtrellis.inc
@@ -5,7 +5,7 @@ SECTION = "devel/fpga"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=551f2364fa8248634340a80a748e986f"
 
-SRC_URI = "git://github.com/SymbiFlow/prjtrellis;protocol=https"
+SRC_URI = "git://github.com/YosysHQ/prjtrellis;protocol=https"
 SRCREV = "f93243b000c52b755c70829768d2ae6bcf7bb91a"
 PV = "0+git${SRCPV}"
 


### PR DESCRIPTION
The main development now happens on https://github.com/YosysHQ/ instead of the SymbiFlow organization.